### PR TITLE
fix(docker-compose): make web host port overridable for macOS (#37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,17 @@ docker-compose up -d --build
 
 The application will be available at `http://localhost:5000`
 
+> **macOS users**: port 5000 is reserved by Control Center (AirPlay
+> Receiver / Handoff) on Monterey+ and the container will fail to bind
+> with `Ports are not available: ... bind: address already in use`.
+> Override the host port instead of disabling AirPlay:
+> ```bash
+> WEB_PORT=8085 docker-compose up -d --build
+> ```
+> Then browse `http://localhost:8085`. The same `WEB_PORT` env var works
+> for all `docker-compose` invocations — see
+> [issue #37](https://github.com/Commando-X/vuln-bank/issues/37).
+
 #### Container recovery behavior
 The Docker setup includes a few operational safeguards so the app can recover without manual SSH intervention:
 - `web` and `db` use `restart: unless-stopped`, so Docker restarts them automatically if the process exits.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,14 @@ services:
     build: .
     restart: unless-stopped
     ports:
-      - "5000:5000"
+      # Host port is overridable so macOS users can sidestep the port-5000
+      # AirPlay Receiver conflict (Monterey+ reserves :5000 for Control
+      # Center). Default is 5000 to keep existing Linux setups unchanged;
+      # set WEB_PORT=8085 (or any free port) before `docker-compose up`
+      # on macOS. See https://github.com/Commando-X/vuln-bank/issues/37.
+      - "${WEB_PORT:-5000}:5000"
       - "80:5000"
-      # - "443:5000" 
+      # - "443:5000"
 
     environment:
       - DB_NAME=vulnerable_bank


### PR DESCRIPTION
Closes #37.

macOS Monterey+ reserves port 5000 for Control Center (AirPlay Receiver / Handoff), so \`docker-compose up\` fails out-of-the-box on Mac with \`Ports are not available: ... bind: address already in use\`. Mac users either had to disable AirPlay system-wide or hand-edit the compose file.

Replaces the hard-coded \`5000:5000\` mapping with \`\${WEB_PORT:-5000}:5000\`. Default stays \`5000\` so existing Linux setups are completely unchanged; Mac users sidestep the conflict with one env var:

\`\`\`bash
WEB_PORT=8085 docker-compose up -d --build
\`\`\`

The README's run section now has a callout explaining the AirPlay conflict + the override, so Mac users don't have to dig through issue history.

I went with the env-var approach instead of the issue's suggested "just change the default to 8085" because:

- Linux + WSL users keep the same port they've always used. Zero docs/curl/walkthrough breakage.
- All existing references in README to \`http://localhost:5000\` (API docs, GraphQL endpoint, merchant integration examples, the upload PoC commands) stay correct.
- One env var works for any other macOS host that happens to have something else on 5000 too — not just Control Center.

\`docker compose config\` round-trips correctly with the override:

\`\`\`
$ WEB_PORT=8085 docker compose config | grep -A 1 published
        published: "5432"     # postgres, unchanged
        published: "8085"     # web — picked up the env var
        published: "80"       # alternate web mapping, unchanged
\`\`\`

Test plan:

- [x] \`docker compose config\` syntactically clean
- [x] Env var override resolves to the supplied port
- [x] Default (no env var) still resolves to 5000
- [x] README callout clearly distinguishes the macOS path from the Linux/WSL path